### PR TITLE
Add outbound queue for PRPC handler

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -300,6 +300,7 @@ async def prpc_wshandler(request):
 
     async def put(data):
         async with ns.cond:
+            # If q is full, oldest message will be discarded upon insertion.
             ns.q.append(data)
             ns.cond.notify()
 


### PR DESCRIPTION
When an unlimited-length queue is used for outbound websocket messages, backpressure from the websocket can cause unlimited queuing leading to OOM on the server (this is bad, never good).

This change introduces a limited-length outbound deque which pushes older messages out to make room for newer messages.

Because the consequences of OOM are very dire, unlimited queue length is not an option.  The default queue length is (very arbitrarily) set to 100 messages.