### PR TITLE
fix ondrain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,15 @@ RUN mkdir -p /alephzero && \
 
 RUN mkdir -p /uNetworking && \
     cd /uNetworking && \
-    git clone --depth 1 --branch v0.7.1 https://github.com/uNetworking/uSockets.git && \
-    git clone --depth 1 --branch v18.23.0  https://github.com/uNetworking/uWebSockets.git && \
+    git clone --depth 1 --branch v0.8.1 https://github.com/uNetworking/uSockets.git && \
+    git clone --depth 1 --branch v20.8.0  https://github.com/uNetworking/uWebSockets.git && \
     cd /uNetworking/uSockets && \
     make -j && \
     mv /uNetworking/uSockets/uSockets.a /uNetworking/uSockets/libuSockets.a
 
 RUN mkdir -p /nlohmann && \
     cd /nlohmann && \
-    wget https://github.com/nlohmann/json/releases/download/v3.9.1/json.hpp
+    wget https://github.com/nlohmann/json/releases/download/v3.10.4/json.hpp
 
 WORKDIR /
 COPY include /include

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ fetch(`http://${api_addr}/api/pub`, {
             ],
             payload: "...",               // required
         },
-        request_encoding: "none"          // optional, one of "none", "base64"
+        request_encoding: "none",         // optional, one of "none", "base64"
     })
 })
 .then((r) => { return r.text() })
@@ -66,8 +66,8 @@ fetch(`http://${api_addr}/api/rpc`, {
             ],
             payload: "...",               // required
         },
-        request_encoding: "none"          // optional, one of "none", "base64"
-        response_encoding: "none"         // optional, one of "none", "base64"
+        request_encoding: "none",         // optional, one of "none", "base64"
+        response_encoding: "none",        // optional, one of "none", "base64"
     })
 })
 .then((r) => { return r.text() })

--- a/include/a0/api/actions/rest_pub.hpp
+++ b/include/a0/api/actions/rest_pub.hpp
@@ -20,7 +20,7 @@ namespace a0::api {
 //             ],
 //             payload: "...",               // required
 //         },
-//         request_encoding: "none"          // optional, one of "none", "base64"
+//         request_encoding: "none",         // optional, one of "none", "base64"
 //     })
 // })
 // .then((r) => { return r.text() })

--- a/include/a0/api/actions/rest_rpc.hpp
+++ b/include/a0/api/actions/rest_rpc.hpp
@@ -21,8 +21,8 @@ namespace a0::api {
 //             ],
 //             payload: "...",               // required
 //         },
-//         request_encoding: "none"          // optional, one of "none", "base64"
-//         response_encoding: "none"         // optional, one of "none", "base64"
+//         request_encoding: "none",         // optional, one of "none", "base64"
+//         response_encoding: "none",        // optional, one of "none", "base64"
 //     })
 // })
 // .then((r) => { return r.text() })

--- a/include/a0/api/actions/rest_write.hpp
+++ b/include/a0/api/actions/rest_write.hpp
@@ -21,7 +21,7 @@ namespace a0::api {
 //             ],
 //             payload: "...",               // required
 //         },
-//         request_encoding: "none"          // optional, one of "none", "base64"
+//         request_encoding: "none",         // optional, one of "none", "base64"
 //     })
 // })
 // .then((r) => { return r.text() })

--- a/include/a0/api/actions/ws_discover.hpp
+++ b/include/a0/api/actions/ws_discover.hpp
@@ -134,12 +134,12 @@ struct WSDiscover {
                               relpath.size() - (protocol_tmpl.size() - tmpl_topic_idx - tmpl_topic.size()));
 
                           auto send_status = ws->send(nlohmann::json{
-                                       {"abspath", path},
-                                       {"relpath", relpath},
-                                       {"topic", topic},
-                                   }
-                                       .dump(),
-                                   uWS::TEXT, true);
+                                                          {"abspath", path},
+                                                          {"relpath", relpath},
+                                                          {"topic", topic},
+                                                      }
+                                                          .dump(),
+                                                      uWS::TEXT, true);
 
                           auto* data = ws->getUserData();
                           if (data->scheduler == scheduler_t::ON_DRAIN && send_status == ws->SUCCESS) {

--- a/include/a0/api/actions/ws_log.hpp
+++ b/include/a0/api/actions/ws_log.hpp
@@ -140,12 +140,12 @@ struct WSLog {
                             return;
                           }
                           auto send_status = ws->send(nlohmann::json(
-                                       {
-                                           {"headers", headers},
-                                           {"payload", payload},
-                                       })
-                                       .dump(),
-                                   uWS::TEXT, true);
+                                                          {
+                                                              {"headers", headers},
+                                                              {"payload", payload},
+                                                          })
+                                                          .dump(),
+                                                      uWS::TEXT, true);
 
                           auto* data = ws->getUserData();
                           if (data->scheduler == scheduler_t::ON_DRAIN && send_status == ws->SUCCESS) {

--- a/include/a0/api/actions/ws_log.hpp
+++ b/include/a0/api/actions/ws_log.hpp
@@ -31,7 +31,7 @@ struct WSLog {
     std::unique_ptr<LogListener> listener;
   };
 
-  static uWS::App::WebSocketBehavior behavior() {
+  static uWS::App::WebSocketBehavior<Data> behavior() {
     return {
         .compression = uWS::SHARED_COMPRESSOR,
         .maxPayloadLength = 16 * 1024 * 1024,
@@ -47,7 +47,7 @@ struct WSLog {
                 return;
               }
 
-              auto* data = (WSLog::Data*)ws->getUserData();
+              auto* data = ws->getUserData();
 
               // If the handshake is complete, and scheduler is ON_ACK, and message is "ACK", unblock the next message.
               if (data->init && data->scheduler == scheduler_t::ON_ACK && msg == std::string_view("ACK")) {
@@ -139,13 +139,19 @@ struct WSLog {
                               !global()->active_ws.count(ws)) {
                             return;
                           }
-                          ws->send(nlohmann::json(
+                          auto send_status = ws->send(nlohmann::json(
                                        {
                                            {"headers", headers},
                                            {"payload", payload},
                                        })
                                        .dump(),
                                    uWS::TEXT, true);
+
+                          auto* data = ws->getUserData();
+                          if (data->scheduler == scheduler_t::ON_DRAIN && send_status == ws->SUCCESS) {
+                            (*data->scheduler_event_count)++;
+                            global()->cv.notify_all();
+                          }
                         });
 
                     // Maybe block log listener callback thread.
@@ -163,7 +169,7 @@ struct WSLog {
             },
         .drain =
             [](auto* ws) {
-              auto* data = (WSLog::Data*)ws->getUserData();
+              auto* data = ws->getUserData();
               if (data->scheduler == scheduler_t::ON_DRAIN && ws->getBufferedAmount() == 0) {
                 (*data->scheduler_event_count)++;
                 global()->cv.notify_all();
@@ -173,7 +179,7 @@ struct WSLog {
         .pong = nullptr,
         .close =
             [](auto* ws, int code, std::string_view msg) {
-              auto* data = (WSLog::Data*)ws->getUserData();
+              auto* data = ws->getUserData();
               *data->scheduler_event_count = -1;
               global()->active_ws.erase(ws);
               global()->cv.notify_all();

--- a/include/a0/api/actions/ws_prpc.hpp
+++ b/include/a0/api/actions/ws_prpc.hpp
@@ -156,12 +156,12 @@ struct WSPrpc {
                       return;
                     }
                     auto send_status = ws->send(nlohmann::json({
-                                                {"headers", strutil::flatten(data->newest_pkt->pkt->headers())},
-                                                {"payload", data->newest_pkt->pkt->payload()},
-                                                {"done", data->newest_pkt->done},
-                                            })
-                                 .dump(),
-                             uWS::TEXT, true);
+                                                                   {"headers", strutil::flatten(data->newest_pkt->pkt->headers())},
+                                                                   {"payload", data->newest_pkt->pkt->payload()},
+                                                                   {"done", data->newest_pkt->done},
+                                                               })
+                                                    .dump(),
+                                                uWS::TEXT, true);
                     data->newest_pkt->pkt = std::nullopt;
 
                     auto* data = ws->getUserData();

--- a/include/a0/api/actions/ws_read.hpp
+++ b/include/a0/api/actions/ws_read.hpp
@@ -130,12 +130,12 @@ struct WSRead {
                             return;
                           }
                           auto send_status = ws->send(nlohmann::json(
-                                       {
-                                           {"headers", headers},
-                                           {"payload", payload},
-                                       })
-                                       .dump(),
-                                   uWS::TEXT, true);
+                                                          {
+                                                              {"headers", headers},
+                                                              {"payload", payload},
+                                                          })
+                                                          .dump(),
+                                                      uWS::TEXT, true);
 
                           auto* data = ws->getUserData();
                           if (data->scheduler == scheduler_t::ON_DRAIN && send_status == ws->SUCCESS) {

--- a/include/a0/api/actions/ws_read.hpp
+++ b/include/a0/api/actions/ws_read.hpp
@@ -30,7 +30,7 @@ struct WSRead {
     std::unique_ptr<Reader> reader;
   };
 
-  static uWS::App::WebSocketBehavior behavior() {
+  static uWS::App::WebSocketBehavior<Data> behavior() {
     return {
         .compression = uWS::SHARED_COMPRESSOR,
         .maxPayloadLength = 16 * 1024 * 1024,
@@ -46,7 +46,7 @@ struct WSRead {
                 return;
               }
 
-              auto* data = (WSRead::Data*)ws->getUserData();
+              auto* data = ws->getUserData();
 
               // If the handshake is complete, and scheduler is ON_ACK, and message is "ACK", unblock the next message.
               if (data->init && data->scheduler == scheduler_t::ON_ACK && msg == std::string_view("ACK")) {
@@ -129,13 +129,19 @@ struct WSRead {
                               !global()->active_ws.count(ws)) {
                             return;
                           }
-                          ws->send(nlohmann::json(
+                          auto send_status = ws->send(nlohmann::json(
                                        {
                                            {"headers", headers},
                                            {"payload", payload},
                                        })
                                        .dump(),
                                    uWS::TEXT, true);
+
+                          auto* data = ws->getUserData();
+                          if (data->scheduler == scheduler_t::ON_DRAIN && send_status == ws->SUCCESS) {
+                            (*data->scheduler_event_count)++;
+                            global()->cv.notify_all();
+                          }
                         });
 
                     // Maybe block reader callback thread.
@@ -153,7 +159,7 @@ struct WSRead {
             },
         .drain =
             [](auto* ws) {
-              auto* data = (WSRead::Data*)ws->getUserData();
+              auto* data = ws->getUserData();
               if (data->scheduler == scheduler_t::ON_DRAIN && ws->getBufferedAmount() == 0) {
                 (*data->scheduler_event_count)++;
                 global()->cv.notify_all();
@@ -163,7 +169,7 @@ struct WSRead {
         .pong = nullptr,
         .close =
             [](auto* ws, int code, std::string_view msg) {
-              auto* data = (WSRead::Data*)ws->getUserData();
+              auto* data = ws->getUserData();
               *data->scheduler_event_count = -1;
               global()->active_ws.erase(ws);
               global()->cv.notify_all();

--- a/include/a0/api/actions/ws_sub.hpp
+++ b/include/a0/api/actions/ws_sub.hpp
@@ -130,12 +130,12 @@ struct WSSub {
                             return;
                           }
                           auto send_status = ws->send(nlohmann::json(
-                                       {
-                                           {"headers", headers},
-                                           {"payload", payload},
-                                       })
-                                       .dump(),
-                                   uWS::TEXT, true);
+                                                          {
+                                                              {"headers", headers},
+                                                              {"payload", payload},
+                                                          })
+                                                          .dump(),
+                                                      uWS::TEXT, true);
 
                           auto* data = ws->getUserData();
                           if (data->scheduler == scheduler_t::ON_DRAIN && send_status == ws->SUCCESS) {

--- a/include/a0/api/global_state.hpp
+++ b/include/a0/api/global_state.hpp
@@ -11,7 +11,7 @@ struct GlobalState {
   std::atomic<bool> running;
   // The following should only be used within the event_loop.
   us_listen_socket_t* listen_socket;
-  std::set<uWS::WebSocket<false, true>*> active_ws;
+  std::set<uWS::AsyncSocket<false>*> active_ws;
   // The following should only be used to lock alephzero threads.
   std::mutex mu;
   std::condition_variable cv;
@@ -37,7 +37,7 @@ void shutdown() {
       global()->listen_socket = nullptr;
     }
     for (auto* ws : global()->active_ws) {
-      ws->close();
+      ((uWS::WebSocket<false, true, void>*)ws)->close();
     }
   });
 }


### PR DESCRIPTION
https://github.com/alephzero/api/issues/27

`send` isn't followed by ondrain if the send is immediately successful and nothing is buffered.
This PR checks the output status of send, which is one of SUCCESS, BACKPRESSURE, or DROPPED.

If SUCCESS, then ondrain wont be called, so we trigger the scheduler immediately,

TODO: Handle the DROPPED use case.

We also upgrade the third-party dependencies. That's unrelated to the main change.
